### PR TITLE
Trivial model reductions (Input/Output pruning)

### DIFF
--- a/script/LiveModel.js
+++ b/script/LiveModel.js
@@ -93,12 +93,16 @@ let LiveModel = {
 		if (force || confirm(Strings.removeNodeCheck(variable['name']))) {
 			// First, explicitly remove all regulations that have something to do with us.
 			let update_regulations_after_delete = [];
+			let to_remove = [];
 			for (var i = 0; i < this._regulations.length; i++) {
 				let reg = this._regulations[i];
 				if (reg.regulator == id || reg.target == id) {
-					this._removeRegulation(reg);
-					update_regulations_after_delete.push(reg.target);
+					to_remove.push(reg);					
 				}
+			}
+			for (reg of to_remove) {
+				this._removeRegulation(reg);
+				update_regulations_after_delete.push(reg.target);
 			}
 			delete this._variables[id];
 			delete this._updateFunctions[id];

--- a/script/LiveModel.js
+++ b/script/LiveModel.js
@@ -48,6 +48,43 @@ let LiveModel = {
 		return id;
 	},
 
+	// Remove constant variables, substituting them with parameters.
+	// If force is true, also remove variables with explicit update functions,
+	// otherwise only remove true constants...
+	pruneConstants(force = false) {
+		var to_remove = [];
+		for (const [id, variable] of Object.entries(this._variables)) {
+			var is_constant = true;
+			is_constant = is_constant & this.regulationsOf(id).length == 0;
+			if (!force) {
+				is_constant = is_constant & this._updateFunctions[id] === undefined;
+			}			
+			if (is_constant) { 
+				to_remove.push(id); 
+			}
+		}
+		console.log("To remove: ", to_remove);
+		for (id of to_remove) {
+			this.removeVariable(id, true);
+		}
+		return to_remove.length;
+	},
+
+	// Remove output variables, i.e. variables that have no outgoing regulations.
+	pruneOutputs() {
+		var to_remove = [];
+		for (const [id, variable] of Object.entries(this._variables)) {
+			if (this.regulationsFrom(id).length == 0) { 
+				to_remove.push(id); 
+			}
+		}
+		console.log("To remove: ", to_remove);
+		for (id of to_remove) {
+			this.removeVariable(id, true);
+		}
+		return to_remove.length;
+	},
+
 	// Remove the given variable from the model.
 	removeVariable(id, force = false) {
 		let variable = this._variables[id];
@@ -151,6 +188,16 @@ let LiveModel = {
 		for (var i = 0; i < this._regulations.length; i++) {
 			let reg = this._regulations[i];
 			if (reg.target == targetId) result.push(reg);
+		}
+		return result;
+	},
+
+	// Return a list of regulations that the given id is a regulator of.
+	regulationsFrom(regulatorId) {
+		let result = [];
+		for (var i = 0; i < this._regulations.length; i++) {
+			let reg = this._regulations[i];
+			if (reg.regulator == regulatorId) result.push(reg);
 		}
 		return result;
 	},


### PR DESCRIPTION
This pull request adds the ability to safely remove all input/output nodes of a network that is currently loaded in the interactive AEON editor.

Input node is a variable with no incoming regulations. Its value is thus effectively constant and can be converted into a parameter.

Output node is a variable with no outgoing regulations. That is, its value cannot influence any other variable. 

The `LiveModel` global object now contains `pruneConstants` and `pruneOutputs` methods that can remove these two classes of variables. The methods are not available via GUI yet, but you can use them from the JavaScript console simply by loading any AEON model and calling `LiveModel.pruneConstants(true)` or `LiveModel.pruneOutputs()`.

Note that additional pruning may be possible since a variable can become an input/output due to some previously removed variable.

This type of reduction is conservative towards attractors as no input value can change in attractor states. Output values can change in attractors, but are independent of all other variables and therefore can't erase or create an attractor. Output pruning thus cannot change the number of attractors, it can however turn disordered attractor into an oscillating one, which may be an acceptable trade-off.

Finally, this also fixes #9, since the problem in regulation iteration during removal has been resolved.